### PR TITLE
Add support for predefined variable ${fileDirbasename}

### DIFF
--- a/src/vs/workbench/services/configurationResolver/node/variableResolver.ts
+++ b/src/vs/workbench/services/configurationResolver/node/variableResolver.ts
@@ -178,6 +178,7 @@ export class AbstractVariableResolverService implements IConfigurationResolverSe
 						case 'file':
 						case 'relativeFile':
 						case 'fileDirname':
+						case 'fileDirbasename':
 						case 'fileExtname':
 						case 'fileBasename':
 						case 'fileBasenameNoExtension':
@@ -226,6 +227,9 @@ export class AbstractVariableResolverService implements IConfigurationResolverSe
 
 						case 'fileDirname':
 							return paths.dirname(filePath);
+							
+						case 'fileDirbasename':
+							return paths.basename(paths.dirname(filePath));
 
 						case 'fileExtname':
 							return paths.extname(filePath);


### PR DESCRIPTION
I would like to purpose an addition to the set of predefined variables that VS Code supports for `tasks.json` and `launch.json`.

Here's my use case.

- I have organized my code in modules, each module is just a folder with files.
- Some file names end with suffixes such as `_test.cc` or `_windows.cc`
- My build system relies on these conventions to generate build targets.

However, I have to be able to specify the surrounding context, i.e. module name without full path information, i.e. this suggested change.

My current workaround looks like this.

launch.json:

```json
{
  "name": "Debug (test)",
  "type": "cppvsdbg",
  "request": "launch",
  "program":
    "${workspaceFolder}/t2-output/win64-msvc-debug-default/temp_${fileBasenameNoExtension}.exe",
  "args": [],
  "stopAtEntry": false,
  "cwd": "${workspaceFolder}",
  "environment": [],
  "externalConsole": false,
  "preLaunchTask": "Build (test)"
}
```

tasks.json:

```json
{
  "label": "Build (test)",
  "type": "shell",
  "command": "build-test ${fileDirname} ${fileBasenameNoExtension}",
  "group": "build",
  "problemMatcher": [
    "$msCompile"
  ]
}
```

build-test.cmd:

```batch
set DIR_BASENAME=

for %%i in (%1) do (
  set DIR_BASENAME=%%~nxi
)

tundra2 "%DIR_BASENAME%_%2"

cd t2-output\win64-msvc-debug-default
del /q "temp_%2.exe" 2>NUL
copy "%DIR_BASENAME%_%2.exe" "temp_%2.exe"
```

It would be nice if I could forgo all the intermediate steps and I think it could be useful for other people as well to be able to refer the surrounding directory name as a basename. My setup was inspired by conventions laid out in the Go project and since package names in Go work in a similar way to my module system I think it could be of use to people doing work in Go as well.

I know this is an incomplete pull request, in that it lacks localized documentation for this new variable but I wanted to know if this was something we could add?